### PR TITLE
Moving nightly to feature.

### DIFF
--- a/examples/actix-example/Cargo.toml
+++ b/examples/actix-example/Cargo.toml
@@ -17,15 +17,10 @@ console_log = "1"
 cfg-if = "1"
 leptos = { version = "0.6", default-features = false, features = [
   "serde",
-  "nightly"
 ] }
-leptos_meta = { version = "0.6", default-features = false, features = [
-  "nightly"
-]}
+leptos_meta = { version = "0.6", default-features = false }
 leptos_actix = { version = "0.6", optional = true }
-leptos_router = { version = "0.6", default-features = false, features = [
-  "nightly"
-]}
+leptos_router = { version = "0.6", default-features = false }
 leptos_server_signal = { path = "../.." }
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
@@ -47,6 +42,7 @@ ssr = [
   "leptos_server_signal/ssr",
   "leptos_server_signal/actix",
 ]
+nightly = ["leptos/nightly", "leptos_meta/nightly", "leptos_router/nightly"]
 
 [package.metadata.leptos]
 # The name used by wasm-bindgen/cargo-leptos for the JS/WASM bundle. Defaults to the crate name   

--- a/examples/actix-example/Cargo.toml
+++ b/examples/actix-example/Cargo.toml
@@ -42,7 +42,6 @@ ssr = [
   "leptos_server_signal/ssr",
   "leptos_server_signal/actix",
 ]
-nightly = ["leptos/nightly", "leptos_meta/nightly", "leptos_router/nightly"]
 
 [package.metadata.leptos]
 # The name used by wasm-bindgen/cargo-leptos for the JS/WASM bundle. Defaults to the crate name   

--- a/examples/axum-example/Cargo.toml
+++ b/examples/axum-example/Cargo.toml
@@ -13,15 +13,10 @@ console_log = "1"
 cfg-if = "1"
 leptos = { version = "0.6", default-features = false, features = [
   "serde",
-  "nightly"
 ] }
-leptos_meta = { version = "0.6", default-features = false, features = [
-  "nightly"
-]}
+leptos_meta = { version = "0.6", default-features = false }
 leptos_axum = { version = "0.6", optional = true }
-leptos_router = { version = "0.6", default-features = false, features = [
-  "nightly"
-]}
+leptos_router = { version = "0.6", default-features = false }
 leptos_server_signal = { path = "../.." }
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
@@ -48,6 +43,7 @@ ssr = [
     "leptos_server_signal/axum",
     "dep:tracing"
 ]
+nightly = ["leptos/nightly", "leptos_meta/nightly", "leptos_router/nightly"]
 
 [package.metadata.cargo-all-features]
 denylist = [

--- a/examples/axum-example/Cargo.toml
+++ b/examples/axum-example/Cargo.toml
@@ -43,7 +43,6 @@ ssr = [
     "leptos_server_signal/axum",
     "dep:tracing"
 ]
-nightly = ["leptos/nightly", "leptos_meta/nightly", "leptos_router/nightly"]
 
 [package.metadata.cargo-all-features]
 denylist = [


### PR DESCRIPTION
Thank you for creating and sharing these server signals.

These examples don't require nightly features, but including them prevents compilation on the stable release channel.

This PR moves the nightly feature of dependencies to be only used when compiled with the "nightly" feature.

You could alternatively remove the feature because the examples work on both stable and nightly without needing the nightly feature.