### PR TITLE
Added a retry timeout.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos_server_signal"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 authors = ["Ari Seyhun <ariseyhun@live.com.au>"]
 description = "Leptos server signals synced through websockets"
@@ -23,7 +23,7 @@ leptos = { version = "0.6", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 wasm-bindgen = { version = "0.2", default-features = false }
-web-sys = { version = "0.3", features = ["WebSocket", "MessageEvent"] }
+web-sys = { version = "0.3", features = ["WebSocket", "MessageEvent", "Window"] }
 thiserror = { version = "1", optional = true }
 
 # Actix

--- a/README.md
+++ b/README.md
@@ -83,3 +83,23 @@ async fn handle_socket(mut socket: WebSocket) {
     }
 }
 ```
+
+# Connection Retry
+
+With the example above, the connection does not get reestablished after a connection lost.
+To regularly try to reconnect again, the function `provide_websocket_with_retry(...)` can
+be used:
+
+```rust
+#[component]
+pub fn App() -> impl IntoView {
+    // Provide websocket connection
+    leptos_server_signal::provide_websocket_with_retry(
+        "ws://localhost:3000/ws",
+        5000, // retry in 5000 milliseconds
+    ).unwrap();
+
+    // ... code from above
+}
+```
+


### PR DESCRIPTION
In this PR a retry timeout is added. 

There is a new function `provide_websocket_with_retry(...)` which takes as second argument the number of milliseconds after which it tries to reconnect again. In this function, after creating the websocket object, it checks if the websocket has really been created and then adds an error handler to the websocket, which activates a timeout. 

After the timeout has exceeded a new inner websocket is created, which inherits all settings from the old inner websocket, including all handlers like the message an error handler. In case the new websocket cannot connect, the error handler is invoked again and activates another timeout. 